### PR TITLE
DevZone Refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11136,6 +11136,12 @@
         "prepend-http": "^2.0.0"
       }
     },
+    "url-search-params-polyfill": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-5.0.0.tgz",
+      "integrity": "sha512-+SCD22QJp4UnqPOI5UTTR0Ljuh8cHbjEf1lIiZrZ8nHTlTixqwVsVQTSfk5vrmDz7N09/Y+ka5jQr0ff35FnQQ==",
+      "dev": true
+    },
     "url-to-options": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ts-jest": "^22.4.4",
     "ts-loader": "^4.2.0",
     "typescript": "^2.8.3",
+    "url-search-params-polyfill": "^5.0.0",
     "webpack": "^4.6.0",
     "webpack-cli": "^2.0.14",
     "webpack-merge": "^4.1.2",

--- a/src/Cognito.ts
+++ b/src/Cognito.ts
@@ -3,7 +3,7 @@ require('amazon-cognito-js');
 import * as AmazonCognitoIdentity from 'amazon-cognito-identity-js';
 import {Logger} from 'Iris-FE/src/logger/Logger';
 import { CognitoUser, CognitoUserPool, CognitoUserSession } from "amazon-cognito-identity-js";
-import { getCredentials, getQueryStringValue } from './DevzoneHelper';
+import { dzRefreshEndpoint, getCredentials, getQueryStringValue } from './DevzoneHelper';
 
 const {CognitoSyncManager, CognitoIdentityCredentials} = AWS; // provided by dist/amazon-cognito.min.js from https://github.com/aws/amazon-cognito-js (NOT Amplify!)
 const {AuthenticationDetails, CognitoUser, CognitoRefreshToken, CognitoUserAttribute, CognitoUserPool} = AmazonCognitoIdentity; // provided by dist/amazon-cognito-identity.min.js from https://github.com/aws/aws-amplify/tree/master/packages/amazon-cognito-identity-js
@@ -314,16 +314,6 @@ namespace Cognito {
 
         }
         throw new Error('No token in storage.');
-    };
-
-    const dzRefreshEndpoint = (stage: "development" | "beta" | "production") => {
-        const base = {
-            "development": "https://local.account.nrfcloud.com/web/refresh/?refreshToken=",
-            "beta": "https://beta.account.nrfcloud.com/web/refresh/?refreshToken=",
-            "production": "https://account.nrfcloud.com/web/refresh/?refreshToken=",
-        };
-
-        return (refreshToken) => `${base[stage]}${refreshToken}`;
     };
 
     export const getUserFromUsername = (username) => {

--- a/src/DevzoneHelper.ts
+++ b/src/DevzoneHelper.ts
@@ -1,0 +1,29 @@
+import * as AWS from 'aws-sdk';
+import 'url-search-params-polyfill';
+
+// URLSearchParams is not supported in IE
+export function getQueryStringValue(key: string) {
+    const params = new URLSearchParams(location.search);
+    return params.get(key);
+}
+
+export function isDevZoneLogin(): boolean {
+    return !!getQueryStringValue('token');
+}
+
+export function getCredentials(): AWS.CognitoIdentityCredentials {
+    const token = getQueryStringValue('token');
+    let cognitoCredentials;
+    if (token) {
+        const {aud: IdentityPoolId, sub: IdentityId} = JSON.parse(atob(token.split('.')[1]));
+        cognitoCredentials = new AWS.CognitoIdentityCredentials({
+            IdentityPoolId,
+            IdentityId,
+            Logins: {
+                'cognito-identity.amazonaws.com': token,
+            },
+        });
+    }
+
+    return cognitoCredentials;
+}

--- a/src/DevzoneHelper.ts
+++ b/src/DevzoneHelper.ts
@@ -27,3 +27,13 @@ export function getCredentials(): AWS.CognitoIdentityCredentials {
 
     return cognitoCredentials;
 }
+
+export const dzRefreshEndpoint = (stage: "development" | "beta" | "production") => {
+    const base = {
+        "development": "https://local.account.nrfcloud.com/web/refresh/?refreshToken=",
+        "beta": "https://beta.account.nrfcloud.com/web/refresh/?refreshToken=",
+        "production": "https://account.nrfcloud.com/web/refresh/?refreshToken=",
+    };
+
+    return (refreshToken) => `${base[stage]}${refreshToken}`;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import AWSAppSyncClient from 'aws-appsync';
 import Cognito from './Cognito';
+import { isDevZoneLogin } from './DevzoneHelper';
 
-export {AWSAppSyncClient, Cognito };
+export {AWSAppSyncClient, Cognito, isDevZoneLogin };


### PR DESCRIPTION
Changes for DevZone Refresh

* Moved stuff from the FE to aws-client (checking for DevZone Login, getting credentials) to DevZoneHelper.ts. There was similar functionality in aws-client, so they might as well be in the same place.
* Extend resumeSession function to work for DevZone
* Include DevZone Refresh endpoints for different stages

PR for the FE https://github.com/NordicPlayground/nrfcloud-web-frontend/pull/318
