### PR TITLE
Simplify stage names

### DIFF
--- a/src/Cognito.ts
+++ b/src/Cognito.ts
@@ -3,7 +3,7 @@ require('amazon-cognito-js');
 import * as AmazonCognitoIdentity from 'amazon-cognito-identity-js';
 
 import { CognitoUser, CognitoUserPool, CognitoUserSession } from "amazon-cognito-identity-js";
-import { dzRefreshEndpoint, getCredentials, getQueryStringValue } from './DevzoneHelper';
+import { dzRefreshEndpoint, getCredentials, getQueryStringValue, Stage } from './DevzoneHelper';
 
 const { CognitoSyncManager, CognitoIdentityCredentials } = AWS; // provided by dist/amazon-cognito.min.js from https://github.com/aws/amazon-cognito-js (NOT Amplify!)
 const { AuthenticationDetails, CognitoUser, CognitoRefreshToken, CognitoUserAttribute, CognitoUserPool } = AmazonCognitoIdentity; // provided by dist/amazon-cognito-identity.min.js from https://github.com/aws/aws-amplify/tree/master/packages/amazon-cognito-identity-js
@@ -267,7 +267,7 @@ namespace Cognito {
         });
     };
 
-    export const resumeSession = async (stage = null): Promise<void> => {
+    export const resumeSession = async (stage: Stage): Promise<void> => {
         const credentials = retrieveRefreshCredentials();
 
         if (

--- a/src/Cognito.ts
+++ b/src/Cognito.ts
@@ -298,8 +298,7 @@ namespace Cognito {
             credentials.devzoneRefreshToken
         ) {
             const dzRefreshToken = credentials.devzoneRefreshToken;
-            const dzRefreshEP = dzRefreshEndpoint(stage);
-            const result = await (window as any).axios(dzRefreshEP(dzRefreshToken));
+            const result = await (window as any).axios(dzRefreshEndpoint(dzRefreshToken, stage));
             const newToken = result && result.data && result.data.token;
             await authenticate(newToken, false);
             return;

--- a/src/DevzoneHelper.ts
+++ b/src/DevzoneHelper.ts
@@ -29,12 +29,16 @@ export function getCredentials(): AWS.CognitoIdentityCredentials {
 }
 
 const dzRefreshEndpointBases = {
-  development: 'https://local.account.nrfcloud.com/web/refresh/?refreshToken=',
+  dev: 'https://local.account.nrfcloud.com/web/refresh/?refreshToken=',
   beta: 'https://beta.account.nrfcloud.com/web/refresh/?refreshToken=',
+  prod: 'https://account.nrfcloud.com/web/refresh/?refreshToken=',
+
+  // Keep these around for compatibility, until they are not used anymore
+  development: 'https://local.account.nrfcloud.com/web/refresh/?refreshToken=',
   production: 'https://account.nrfcloud.com/web/refresh/?refreshToken=',
 };
 
-export type Stage = 'development' | 'beta' | 'production';
+export type Stage = 'dev' | 'beta' | 'prod' | 'development' | 'production';
 
 export const dzRefreshEndpoint = (refreshToken: string, stage: Stage) =>
   `${dzRefreshEndpointBases[stage]}${refreshToken}`;

--- a/src/DevzoneHelper.ts
+++ b/src/DevzoneHelper.ts
@@ -28,12 +28,11 @@ export function getCredentials(): AWS.CognitoIdentityCredentials {
     return cognitoCredentials;
 }
 
-export const dzRefreshEndpoint = (stage: "development" | "beta" | "production") => {
-    const base = {
-        "development": "https://local.account.nrfcloud.com/web/refresh/?refreshToken=",
-        "beta": "https://beta.account.nrfcloud.com/web/refresh/?refreshToken=",
-        "production": "https://account.nrfcloud.com/web/refresh/?refreshToken=",
-    };
-
-    return (refreshToken) => `${base[stage]}${refreshToken}`;
+const dzRefreshEndpointBases = {
+  development: 'https://local.account.nrfcloud.com/web/refresh/?refreshToken=',
+  beta: 'https://beta.account.nrfcloud.com/web/refresh/?refreshToken=',
+  production: 'https://account.nrfcloud.com/web/refresh/?refreshToken=',
 };
+
+export const dzRefreshEndpoint = (refreshToken: string, stage: 'development' | 'beta' | 'production') =>
+  `${dzRefreshEndpointBases[stage]}${refreshToken}`;

--- a/src/DevzoneHelper.ts
+++ b/src/DevzoneHelper.ts
@@ -34,5 +34,7 @@ const dzRefreshEndpointBases = {
   production: 'https://account.nrfcloud.com/web/refresh/?refreshToken=',
 };
 
-export const dzRefreshEndpoint = (refreshToken: string, stage: 'development' | 'beta' | 'production') =>
+export type Stage = 'development' | 'beta' | 'production';
+
+export const dzRefreshEndpoint = (refreshToken: string, stage: Stage) =>
   `${dzRefreshEndpointBases[stage]}${refreshToken}`;


### PR DESCRIPTION
In https://github.com/NordicPlayground/nrfcloud-web-frontend/pull/458 I am working towards not using `development` and `production` anymore, just the shorter variants `dev` and `prod`. At least where reasonable. This PR enables this when calling `resumeSession()`.

After this PR gets merged into master, I would release a new version of the aws-client (2.1.0?) and use that in the frontend.